### PR TITLE
Update gitpod button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Read more about how to use Jupyter Notebooks with Gitpod in [our documentation.]
 
 Click the button below to start a new cloud development environment:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Siddhant-K-code/template-jupyter-notebook)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-samples/template-jupyter-notebook)


### PR DESCRIPTION
Although the button link will break every time someone uses this template to create a repository, the link update will be still useful when using this template for demonstration purposes. 